### PR TITLE
Enable custom properties

### DIFF
--- a/src/main/java/com/thetsajeet/dbv/DBVAutoConfiguration.java
+++ b/src/main/java/com/thetsajeet/dbv/DBVAutoConfiguration.java
@@ -17,8 +17,9 @@ class DBVAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public DatabaseValidationService databaseValidationService(DataSource dataSource,
-                                                               EntityManagerFactory entityManagerFactory) {
-        return new DatabaseValidationService(dataSource, entityManagerFactory);
+                                                               EntityManagerFactory entityManagerFactory,
+                                                               DbvStarterProperties properties) {
+        return new DatabaseValidationService(dataSource, entityManagerFactory, properties);
     }
 
     @Bean

--- a/src/main/java/com/thetsajeet/dbv/DatabaseValidationService.java
+++ b/src/main/java/com/thetsajeet/dbv/DatabaseValidationService.java
@@ -15,6 +15,8 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @Slf4j
@@ -23,25 +25,39 @@ class DatabaseValidationService {
 
     private final DataSource dataSource;
     private final EntityManagerFactory entityManagerFactory;
+    private final DbvStarterProperties properties;
 
     public void execute() throws SQLException {
         try(Connection connection = dataSource.getConnection()) {
             log.info("Database connection successful");
             DatabaseMetaData metaData = connection.getMetaData();
-
             log.info("Scanning all available entities...");
-            for(EntityType<?> entity : entityManagerFactory.getMetamodel().getEntities()) {
 
+            for(EntityType<?> entity : entityManagerFactory.getMetamodel().getEntities()) {
                 Class<?> javaType = entity.getJavaType();
                 String tableName = getTableNameFromEntity(javaType);
 
-                try (ResultSet tables = metaData.getTables(null, connection.getSchema(), tableName.toLowerCase(), new String[]{"TABLE", "VIEW"})) {
+                // Build table types based on configuration
+                List<String> tableTypes = new ArrayList<>();
+                if (properties.isVerifyTables()) {
+                    tableTypes.add("TABLE");
+                }
+                if (properties.isVerifyViews()) {
+                    tableTypes.add("VIEW");
+                }
+
+                // Skip validation if no types are enabled
+                if (tableTypes.isEmpty()) {
+                    log.info("Table and view verification are both disabled. Skipping validation.");
+                    return;
+                }
+
+                try (ResultSet tables = metaData.getTables(null, connection.getSchema(), tableName.toLowerCase(), tableTypes.toArray(new String[0]))) {
                     if(!tables.next()) {
                         log.warn("Error: For entity: {}, table {} does not exist in the database!", javaType.getSimpleName(), tableName);
                         continue;
                     }
                     log.info("Table {} exists in the database.", tableName);
-
                     validateColumns(entity, tableName, connection, metaData);
                 }
             }
@@ -61,26 +77,22 @@ class DatabaseValidationService {
                 return tableAnnotation.name();
             }
         }
-
         return entityManagerFactory.getMetamodel().entity(entityClass).getName();
     }
 
     private void validateColumns(EntityType<?> entity, String tableName, Connection conn, DatabaseMetaData metaData) throws SQLException {
         log.info("Scanning all columns in {}", entity.getName());
-
         for (Field field : entity.getJavaType().getDeclaredFields()) {
             // ignore static fields
             if (Modifier.isStatic(field.getModifiers()))
                 continue;
 
             String columnName = getColumnNameFromField(field);
-
             try (ResultSet rs = metaData.getColumns(null, conn.getSchema(), tableName, columnName)) {
                 if(!rs.next()) {
                     log.info("Missing column: {}", columnName);
                     continue;
                 }
-
                 log.info("Column found: {}", columnName);
             }
         }

--- a/src/main/java/com/thetsajeet/dbv/DbvStarterProperties.java
+++ b/src/main/java/com/thetsajeet/dbv/DbvStarterProperties.java
@@ -1,0 +1,28 @@
+package com.thetsajeet.dbv;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "dbv.springboot.starter")
+public class DbvStarterProperties {
+
+    private boolean verifyTables = true;
+    private boolean verifyViews = false;
+
+    public boolean isVerifyTables() {
+        return verifyTables;
+    }
+
+    public void setVerifyTables(boolean verifyTables) {
+        this.verifyTables = verifyTables;
+    }
+
+    public boolean isVerifyViews() {
+        return verifyViews;
+    }
+
+    public void setVerifyViews(boolean verifyViews) {
+        this.verifyViews = verifyViews;
+    }
+}


### PR DESCRIPTION
## Changes

- Added `DbvStarterProperties` configuration class with `@ConfigurationProperties` to support custom properties
- Integrated properties into `DatabaseValidationService`
- Added configuration flags:
  - `dbv.springboot.starter.verify-tables` (default: `true`)
  - `dbv.springboot.starter.verify-views` (default: `false`)

Resolves Fixes #16

## Benefits

- Enables flexible configuration for table and view verification
- Maintains backward compatibility with default settings
- Provides better control over validation behavior